### PR TITLE
Fix handling of `tool` header

### DIFF
--- a/hoa/ast/boolean_expression.py
+++ b/hoa/ast/boolean_expression.py
@@ -222,7 +222,7 @@ def _simplify_monotone_op_operands(cls, *operands):
     elif len(operands) == 1:
         return (operands[0],)
     elif cls._absorbing in operands:
-        return cls._absorbing
+        return (cls._absorbing,)
 
     # shift-up subformulas with same operator. DFS on expression tree.
     new_operands = []

--- a/hoa/ast/boolean_expression.py
+++ b/hoa/ast/boolean_expression.py
@@ -55,44 +55,6 @@ class UnaryOp(Generic[T]):
         return f"{type(self).__name__}({repr(self.argument)})"
 
 
-@dataclass(order=True, unsafe_hash=True, frozen=True)
-class TrueFormula:
-    """A tautology."""
-
-    def __str__(self) -> str:
-        """Get the string representation."""
-        return "(true)"
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return "TrueFormula()"
-
-    def __neg__(self) -> "FalseFormula":
-        """Negate."""
-        return FALSE
-
-
-@dataclass(order=True, unsafe_hash=True, frozen=True)
-class FalseFormula:
-    """A contradiction."""
-
-    def __str__(self) -> str:
-        """Get the string representation."""
-        return "(false)"
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return "FalseFormula()"
-
-    def __neg__(self) -> "TrueFormula":
-        """Negate."""
-        return TRUE
-
-
-TRUE = TrueFormula()
-FALSE = FalseFormula()
-
-
 class MonotoneOp(type):
     """Metaclass to simplify monotone operator instantiations."""
 
@@ -110,29 +72,95 @@ class MonotoneOp(type):
 class _And(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """And operator."""
 
-    _absorbing = FALSE
+    _absorbing = None
     SYMBOL = "&"
 
 
 class _Or(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """Or operator."""
 
-    _absorbing = TRUE
+    _absorbing = None
     SYMBOL = "|"
 
 
 class _PositiveAnd(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """And operator."""
 
-    _absorbing = FALSE
+    _absorbing = None
     SYMBOL = "&"
 
 
 class _PositiveOr(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """Or operator."""
 
-    _absorbing = TRUE
+    _absorbing = None
     SYMBOL = "|"
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class TrueFormula:
+    """A tautology."""
+
+    def __str__(self) -> str:
+        """Get the string representation."""
+        return "(true)"
+
+    def __repr__(self) -> str:
+        """Get an unambiguous string representation."""
+        return "TrueFormula()"
+
+    def __and__(self, other):
+        """Return self & other."""
+        return _And(self, other)
+
+    def __or__(self, other):
+        """Return self | other."""
+        return _Or(self, other)
+
+    def __neg__(self) -> "FalseFormula":
+        """Negate."""
+        return FALSE
+
+    def __invert__(self) -> "FalseFormula":
+        """Negate."""
+        return FALSE
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class FalseFormula:
+    """A contradiction."""
+
+    def __str__(self) -> str:
+        """Get the string representation."""
+        return "(false)"
+
+    def __repr__(self) -> str:
+        """Get an unambiguous string representation."""
+        return "FalseFormula()"
+
+    def __and__(self, other):
+        """Return self & other."""
+        return _And(self, other)
+
+    def __or__(self, other):
+        """Return self | other."""
+        return _Or(self, other)
+
+    def __neg__(self) -> "TrueFormula":
+        """Negate."""
+        return TRUE
+
+    def __invert__(self) -> "TrueFormula":
+        """Negate."""
+        return TRUE
+
+
+TRUE = TrueFormula()
+FALSE = FalseFormula()
+_And._absorbing = FALSE
+_Or._absorbing = TRUE
+_PositiveAnd._absorbing = FALSE
+_PositiveOr._absorbing = TRUE
 
 
 class _Not(UnaryOp, Generic[T]):

--- a/hoa/parsers.py
+++ b/hoa/parsers.py
@@ -207,12 +207,19 @@ class HOATransformer(Transformer):
         actual_nb_accepting_sets = nb_accepting_sets(acceptance_condition)
         accepting_sets_ = accepting_sets(acceptance_condition)
         # this checks whether the number of acc. sets in the acceptance condition is correct.
-        assert_(
-            max(accepting_sets_)
-            == len(accepting_sets_) - 1
-            == expected_nb_accepting_sets - 1
-            == actual_nb_accepting_sets - 1
-        )
+        if expected_nb_accepting_sets > 0:
+            assert_(
+                max(accepting_sets_)
+                ==  len(accepting_sets_) - 1
+                == expected_nb_accepting_sets - 1
+                == actual_nb_accepting_sets - 1,
+            )
+        else:
+            assert_(
+                len(accepting_sets_)
+                == expected_nb_accepting_sets
+                == actual_nb_accepting_sets,
+            )
         return HeaderItemType.ACCEPTANCE, acceptance_condition
 
     def acc_name(self, args):

--- a/hoa/parsers.py
+++ b/hoa/parsers.py
@@ -228,7 +228,7 @@ class HOATransformer(Transformer):
 
     def tool(self, args):
         """Parse the 'tool' node."""
-        return HeaderItemType.TOOL, args[0]
+        return HeaderItemType.TOOL, tuple(x.strip('"') for x in args)
 
     def name(self, args):
         """Parse the 'nome' node."""

--- a/hoa/parsers.py
+++ b/hoa/parsers.py
@@ -228,7 +228,7 @@ class HOATransformer(Transformer):
 
     def tool(self, args):
         """Parse the 'tool' node."""
-        return HeaderItemType.TOOL, tuple(x.strip('"') for x in args)
+        return HeaderItemType.TOOL, tuple(args)
 
     def name(self, args):
         """Parse the 'nome' node."""

--- a/tests/examples/aut12.hoa
+++ b/tests/examples/aut12.hoa
@@ -1,0 +1,18 @@
+HOA: v1
+name: "(Fa & G(b&Xc)) | c"
+States: 4
+Start: 0&2
+Start: 3
+Acceptance: 0 t
+AP: 3 "a" "b" "c"
+--BODY--
+State: 0 "Fa"
+[t] 0
+[0] 1
+State: 1 "true"
+[t] 1
+State: 2 "G(b&Xc)"
+[1] 2&3
+State: 3 "c"
+[2] 1
+--END--

--- a/tests/examples/strix-Ga.hoa
+++ b/tests/examples/strix-Ga.hoa
@@ -1,0 +1,14 @@
+HOA: v1
+name: "G a"
+tool: "strix" "21.0.0"
+States: 2
+Start: 0
+AP: 1 "a"
+acc-name: all
+Acceptance: 0 t
+--BODY--
+State: 0 "[0]"
+[(t) & (0)] 1
+State: 1 "[1]"
+[(t) & (0)] 1
+--END--

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -17,7 +17,7 @@
 
 """This module contains the test for the 'hoa.ast.label' module."""
 
-from hoa.ast.boolean_expression import And, Not, Or
+from hoa.ast.boolean_expression import And, FalseFormula, Not, Or, TrueFormula
 from hoa.ast.label import LabelAlias, LabelAtom, propositions
 from hoa.types import alias
 
@@ -38,3 +38,37 @@ def test_propositions():
     assert isinstance(not_, Not)
 
     assert propositions(not_) == {0, 1, 2}
+
+
+def test_constants():
+    """Test the handling of t, f in Boolean operations."""
+    t = TrueFormula()
+    f = FalseFormula()
+
+    neg_t = -t
+    inv_t = ~t
+    neg_f = -f
+    inv_f = ~f
+
+    assert isinstance(neg_t, FalseFormula)
+    assert isinstance(inv_t, FalseFormula)
+    assert isinstance(neg_f, TrueFormula)
+    assert isinstance(inv_f, TrueFormula)
+
+    f_and_t = f & t
+    f_and_f = f & f
+    t_and_f = t & f
+    t_and_t = t & t
+    f_or_f = f | f
+    f_or_t = f | t
+    t_or_f = t | f
+    t_or_t = t | t
+
+    assert isinstance(f_and_f, FalseFormula)
+    assert isinstance(t_and_f, FalseFormula)
+    assert isinstance(f_and_t, FalseFormula)
+    assert isinstance(t_and_t, TrueFormula)
+    assert isinstance(f_or_f, FalseFormula)
+    assert isinstance(f_or_t, TrueFormula)
+    assert isinstance(t_or_f, TrueFormula)
+    assert isinstance(t_or_t, TrueFormula)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 from hoa.ast.acceptance import Fin, Inf, nb_accepting_sets
-from hoa.ast.boolean_expression import TRUE, TrueFormula
+from hoa.ast.boolean_expression import TRUE, And, TrueFormula
 from hoa.ast.label import LabelAlias, LabelAtom
 from hoa.core import Acceptance, Edge, HOA, HOABody, HOAHeader, State
 from hoa.dumpers import dump
@@ -620,6 +620,44 @@ class TestParsingAut12:
             Edge([2, 3], label=LabelAtom(1))
         ]
         state_edges_dict[State(3, name=string("c"))] = [Edge([1], label=LabelAtom(2))]
+        hoa_body = HOABody(state_edges_dict)
+
+        hoa_obj = HOA(hoa_header, hoa_body)
+        assert self.hoa_obj == hoa_obj
+
+
+class TestParsingStrixGa:
+    """Test parsing for tests/examples/strix-Ga."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        parser = HOAParser()
+        cls.hoa_obj: HOA = parser(
+            Path(TEST_ROOT_DIR, "examples", "strix-Ga.hoa").read_text()
+        )
+        cls.hoa_header = cls.hoa_obj.header
+        cls.hoa_body = cls.hoa_obj.body
+
+    def test_hoa(self):
+        """Test that the HOA automaton is correct."""
+        hoa_header = HOAHeader(
+            identifier("v1"),
+            Acceptance(TrueFormula(), "all"),
+            nb_states=2,
+            start_states={frozenset([0])},
+            propositions=(string("a"),),
+            tool=("strix", "21.0.0"),
+            name=string("G a"),
+        )
+
+        state_edges_dict = OrderedDict({})
+        state_edges_dict[State(0, name=string("[0]"))] = [
+            Edge([1], label=And(TrueFormula(), LabelAtom(0))),
+        ]
+        state_edges_dict[State(1, name=string("[1]"))] = [
+            Edge([1], label=And(TrueFormula(), LabelAtom(0))),
+        ]
         hoa_body = HOABody(state_edges_dict)
 
         hoa_obj = HOA(hoa_header, hoa_body)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -647,7 +647,7 @@ class TestParsingStrixGa:
             nb_states=2,
             start_states={frozenset([0])},
             propositions=(string("a"),),
-            tool=("strix", "21.0.0"),
+            tool=('"strix"', '"21.0.0"'),
             name=string("G a"),
         )
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 from hoa.ast.acceptance import Fin, Inf, nb_accepting_sets
-from hoa.ast.boolean_expression import TRUE
+from hoa.ast.boolean_expression import TRUE, TrueFormula
 from hoa.ast.label import LabelAlias, LabelAtom
 from hoa.core import Acceptance, Edge, HOA, HOABody, HOAHeader, State
 from hoa.dumpers import dump
@@ -573,6 +573,46 @@ class TestParsingAut11:
         state_edges_dict = OrderedDict({})
         state_edges_dict[State(0, name=string("Fa"))] = [
             Edge([0], label=TRUE, acc_sig=frozenset({0})),
+            Edge([1], label=LabelAtom(0)),
+        ]
+        state_edges_dict[State(1, name=string("true"))] = [Edge([1], label=TRUE)]
+        state_edges_dict[State(2, name=string("G(b&Xc)"))] = [
+            Edge([2, 3], label=LabelAtom(1))
+        ]
+        state_edges_dict[State(3, name=string("c"))] = [Edge([1], label=LabelAtom(2))]
+        hoa_body = HOABody(state_edges_dict)
+
+        hoa_obj = HOA(hoa_header, hoa_body)
+        assert self.hoa_obj == hoa_obj
+
+
+class TestParsingAut12:
+    """Test parsing for tests/examples/aut11."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        parser = HOAParser()
+        cls.hoa_obj: HOA = parser(
+            Path(TEST_ROOT_DIR, "examples", "aut12.hoa").read_text()
+        )
+        cls.hoa_header = cls.hoa_obj.header
+        cls.hoa_body = cls.hoa_obj.body
+
+    def test_hoa(self):
+        """Test that the HOA automaton is correct."""
+        hoa_header = HOAHeader(
+            identifier("v1"),
+            Acceptance(TrueFormula(), None),
+            nb_states=4,
+            start_states={frozenset([0, 2]), frozenset([3])},
+            propositions=(string("a"), string("b"), string("c")),
+            name=string("(Fa & G(b&Xc)) | c"),
+        )
+
+        state_edges_dict = OrderedDict({})
+        state_edges_dict[State(0, name=string("Fa"))] = [
+            Edge([0], label=TRUE),
             Edge([1], label=LabelAtom(0)),
         ]
         state_edges_dict[State(1, name=string("true"))] = [Edge([1], label=TRUE)]


### PR DESCRIPTION
## Proposed changes

The (optional) `tool` header takes 1 or 2 strings. The second string, if present, indicates the version of the tool.
It is used, e.g., by `strix`:
```
tool: "strix" "21.0.0"
```

However, `pyhoafparser` would take a HOA with a header like the one above and output this:

```
tool: " s t r i x "
```


## Fixes

We fix the bug described above.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
